### PR TITLE
Reduce image size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GEN_BINS = $(TARGET).bin
 SUBDIRS = 	\
 	$(TOP_DIR)/app	\
 	$(TOP_DIR)/platform/boot/$(COMPILE)
-	#	$(TOP_DIR)/demo
+#	$(TOP_DIR)/demo
 endif # } PDIR
 
 ifndef PDIR # {
@@ -36,9 +36,15 @@ SUBDIRS += \
 	$(TOP_DIR)/platform/common 		\
 	$(TOP_DIR)/platform/drivers		\
 	$(TOP_DIR)/platform/sys			\
-	$(TOP_DIR)/src/network	\
-	$(TOP_DIR)/src/os			\
-	$(TOP_DIR)/src/app
+	$(TOP_DIR)/src/network			\
+	$(TOP_DIR)/src/os				\
+	$(TOP_DIR)/src/app/dhcpserver	\
+	$(TOP_DIR)/src/app/dnsserver	\
+	$(TOP_DIR)/src/app/httpclient	\
+	$(TOP_DIR)/src/app/matrixssl	\
+	$(TOP_DIR)/src/app/oneshotconfig	\
+	$(TOP_DIR)/src/app/ota			\
+	$(TOP_DIR)/src/app/web
 endif
 endif
 
@@ -55,8 +61,14 @@ COMPONENTS_$(TARGET) += \
 	$(TOP_DIR)/platform/drivers/libdrivers$(LIB_EXT)		\
 	$(TOP_DIR)/platform/sys/libsys$(LIB_EXT)			\
 	$(TOP_DIR)/src/network/libnetwork$(LIB_EXT)	\
-	$(TOP_DIR)/src/os/libos$(LIB_EXT)			\
-	$(TOP_DIR)/src/app/libapp$(LIB_EXT)
+	$(TOP_DIR)/src/os/libos$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/dhcpserver/libdhcpserver$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/dnsserver/libdnsserver$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/httpclient/libhttpclient$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/matrixssl/libmatrixssl$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/oneshotconfig/liboneshotconfig$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/ota/libota$(LIB_EXT)	\
+	$(TOP_DIR)/src/app/web/libweb$(LIB_EXT)
 endif
 
 

--- a/include/wm_config.h
+++ b/include/wm_config.h
@@ -22,8 +22,8 @@
 #define TLS_CONFIG_UART									CFG_ON  /*UART*/
 
 /**Host Interface&Command**/
-#define TLS_CONFIG_HOSTIF 								CFG_ON
-#define TLS_CONFIG_AT_CMD								(CFG_ON && TLS_CONFIG_HOSTIF)
+#define TLS_CONFIG_HOSTIF 								CFG_OFF
+#define TLS_CONFIG_AT_CMD								(CFG_OFF && TLS_CONFIG_HOSTIF)
 #define TLS_CONFIG_RI_CMD								(CFG_ON && TLS_CONFIG_HOSTIF)
 #define TLS_CONFIG_RMMS									CFG_OFF
 
@@ -42,7 +42,7 @@
 #define	TLS_CONFIG_HARD_CRYPTO							CFG_ON
 
 #define TLS_CONFIG_USE_POLARSSL           				CFG_OFF
-#define TLS_CONFIG_SERVER_SIDE_SSL                      (CFG_ON && TLS_CONFIG_HTTP_CLIENT_SECURE)         /*MUST configure TLS_CONFIG_HTTP_CLIENT_SECURE CFG_ON */
+#define TLS_CONFIG_SERVER_SIDE_SSL                      (CFG_OFF && TLS_CONFIG_HTTP_CLIENT_SECURE)         /*MUST configure TLS_CONFIG_HTTP_CLIENT_SECURE CFG_ON */
 
 
 /** HTTP CLIENT **/
@@ -70,13 +70,14 @@ CRYPTO
 #define TLS_CONFIG_DLNA                          		CFG_OFF && TLS_CONFIG_UPNP
 
 
-#define TLS_CONFIG_NTP 									CFG_ON
+#define TLS_CONFIG_NTP 									CFG_OFF
 
 
 #define  VERC_DNS_OPT						            CFG_ON
 #define  VERC_LWIP_OPT                                  CFG_ON
 #include "wm_os_config.h"  //if you want to use source code,please open
-#include "wm_wifi_config.h"
+#include "wm_wifi_config.h"
+
 
 #include "wm_ram_config.h"
 #endif /*__WM_CONFIG_H__*/

--- a/tools/rules.mk
+++ b/tools/rules.mk
@@ -69,6 +69,9 @@ $(BINODIR)/%.bin: $(IMAGEODIR)/%.out
 	@mkdir -p $(FIRMWAREDIR)
 	@mkdir -p $(FIRMWAREDIR)/$(TARGET)
 ifeq ($(COMPILE), gcc)
+	@echo ""
+	@$(SIZE) $(IMAGEODIR)/$(TARGET).out
+	@echo ""
 	@$(OBJCOPY) --output-target=binary -S -g -x -X -R .sbss -R .bss -R .reginfo -R .stack $(IMAGEODIR)/$(TARGET).out $(FIRMWAREDIR)/$(TARGET)/$(TARGET).bin	
 else
 	@$(FROMELF) --bin -o  $(FIRMWAREDIR)/$(TARGET)/$(TARGET).bin $(IMAGEODIR)/$(TARGET).out  

--- a/tools/tool_chain.def
+++ b/tools/tool_chain.def
@@ -43,6 +43,7 @@ ifeq ($(COMPILE), gcc)
 		LINK = $(TOOL_CHAIN_PATH)arm-none-eabi-ld.exe
 		OBJCOPY = $(TOOL_CHAIN_PATH)arm-none-eabi-objcopy
 		OBJDUMP = $(TOOL_CHAIN_PATH)arm-none-eabi-objdump
+		SIZE = $(TOOL_CHAIN_PATH)arm-none-eabi-size
 	else
 		AR = $(TOOL_CHAIN_PATH)arm-none-eabi-ar
 		ASM = @echo "GNU-ASM $<"; $(TOOL_CHAIN_PATH)arm-none-eabi-gcc
@@ -51,6 +52,7 @@ ifeq ($(COMPILE), gcc)
 		LINK = @echo "GNU-LINK $<"; $(TOOL_CHAIN_PATH)arm-none-eabi-ld.exe
 		OBJCOPY = @echo "GNU-OBJCOPY $<"; $(TOOL_CHAIN_PATH)arm-none-eabi-objcopy
 		OBJDUMP = @echo "GNU-OBJDUMP $<"; $(TOOL_CHAIN_PATH)arm-none-eabi-objdump
+		SIZE = @echo "GNU-SIZE $<"; $(TOOL_CHAIN_PATH)arm-none-eabi-size
 	endif
 else
 	KEIL_PATH =  /cygdrive/d/Keil_V5/ARM


### PR DESCRIPTION
This PR reduces the build size but not including APIs, etc for OpenShw build

* Disabled APIs for TLS_CONFIG_AT_CMD and TLS_CONFIG_RI_CMD - we don't use it
* Disabled TLS_CONFIG_SERVER_SIDE_SSL - we don't use it
* Disabled TLS_CONFIG_NTP since we have our own NTP implementation

* Added size to build script so that one can see image sections size

```	GNU-SIZE .output/w600/image/w600.out
	   text    data     bss     dec     hex filename
	 471844    8032  116580  596456   919e8 .output/w600/image/w600.out
```

The default build script includes all subfolders under `src/app` but a limited ones are used for our build. Manually edited the list to include what is needed.

All this seemed to have reduced the image size by a considerable amount.


Before SDK changes

	fls was 568KB

	GNU-SIZE .output/w600/image/w600.out
	   text    data     bss     dec     hex filename
	 513324   10296  122220  645840   9dad0 .output/w600/image/w600.out
	 
After SDK changes

	fls was 525KB
	
	GNU-SIZE .output/w600/image/w600.out
	   text    data     bss     dec     hex filename
	 471844    8032  116580  596456   919e8 .output/w600/image/w600.out


I have only tested these changes from Cygwin but I think they should give similar results in Github build.