### PR TITLE
Remove oneshotconfig completely

### DIFF
--- a/src/app/dnsserver/dns_server.c
+++ b/src/app/dnsserver/dns_server.c
@@ -268,8 +268,8 @@ void DNSS_RecvCb(void *Arg, struct udp_pcb *Pcb, struct pbuf *P, ip_addr_t *Addr
 		}
 
 		if ((_DnsCompareName(DnsServer.DnsName, pDnsName) != 0) &&
-		    !((1 == tls_wifi_get_oneshot_flag()) &&
-		     (2 == tls_wifi_get_oneshot_config_mode())))
+		    !((1 == 0 /*tls_wifi_get_oneshot_flag()*/) &&
+		     (2 == 0 /*tls_wifi_get_oneshot_config_mode()*/)))
 		{
 			/* Not my dns name, so notify the client name error. */
 #if TLS_CONFIG_AP

--- a/src/network/lwip2.0.3/netif/wm_ethernet.c
+++ b/src/network/lwip2.0.3/netif/wm_ethernet.c
@@ -81,7 +81,7 @@ static void netif_status_changed(struct netif *netif, u8_t netif_state)
 		{
 			if(status_event->status_callback != NULL)
 			{
-				if (0 == tls_wifi_get_oneshot_flag())
+				if (0 == 0 /*tls_wifi_get_oneshot_flag()*/)
 				{
 					if (ip_addr_isany(netif_ip4_addr(netif)))
 					{


### PR DESCRIPTION
We do not use wifi configureation via oneshot for W600/800.

The code under app/oneshotconfig uses app/web to serve static pages for connection. The page content is defined as static char array in `sdk\OpenW600\src\app\web\fsdata_html.h` and `sdk\OpenW600\src\app\web\fsdata_ap_config_html.h` and become part of the image.

I have removed app/oneshotconfig and app/web from makeFile sources and adjusted some callers. This reduced the OTA image size down by another 20KB

Before

	GNU-SIZE .output/w600/image/w600.out
	   text    data     bss     dec     hex filename
	 469100    8032  116564  593696   90f20 .output/w600/image/w600.out
	 
	OTA file was 311KB

After

	GNU-SIZE .output/w600/image/w600.out
	   text    data     bss     dec     hex filename
	440988    7920  108412  557320   88108 .output/w600/image/w600.out
	 
	OTA file was 296KB

The submodules in https://github.com/openshwprojects/OpenBK7231T_App need to be updated after merging this.